### PR TITLE
Pass `instance` via type variable to callback type

### DIFF
--- a/lib/rbs_discard/sig/discard.rbs
+++ b/lib/rbs_discard/sig/discard.rbs
@@ -3,13 +3,13 @@
 module ::Discard
   module ::Discard::Model
     module ::Discard::Model::ClassMethods
-      type ::Discard::Model::ClassMethods::callback = ::Symbol | ^() [self: instance] -> void
+      type ::Discard::Model::ClassMethods::callback[T] = ::Symbol | ^() [self: T] -> void
 
       def discard_column: () -> ::Symbol
       def discard_column=: (::Symbol) -> ::Symbol
 
-      def before_discard: (*::Discard::Model::ClassMethods::callback) ? { () [self: instance] -> void } -> void
-      def after_discard: (*::Discard::Model::ClassMethods::callback) ? { () [self: instance] -> void } -> void
+      def before_discard: (*::Discard::Model::ClassMethods::callback[instance]) ? { () [self: instance] -> void } -> void
+      def after_discard: (*::Discard::Model::ClassMethods::callback[instance]) ? { () [self: instance] -> void } -> void
       def discard_all: () -> void
       def discard_all!: () -> void
       def undiscard_all: () -> void


### PR DESCRIPTION
To avoid a warning from `rbs validate`, pass `instance` via type variable to the callback type.