### PR TITLE
Enable the rubocop-rbs_inline plugin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.2'
           - '3.3'
           - '3.4'
           - '4.0'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ plugins:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
 
 Style/Documentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 plugins:
   - rubocop-rake
+  - rubocop-rbs_inline
   - rubocop-rspec
 
 AllCops:
@@ -7,6 +8,15 @@ AllCops:
 
 Style/Documentation:
   Enabled: false
+
+Style/RbsInline/MissingTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RedundantTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RequireRbsInlineComment:
+  EnforcedStyle: never
 
 Style/StringLiterals:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "rake", "~> 13.4"
 
 gem "rubocop", "~> 1.88"
 gem "rubocop-rake"
+gem "rubocop-rbs_inline"
 gem "rubocop-rspec"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,10 @@ GEM
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
+    rubocop-rbs_inline (1.5.5)
+      lint_roller (~> 1.1)
+      rbs-inline
+      rubocop (>= 1.72.1, < 2.0)
     rubocop-rspec (3.10.2)
       lint_roller (~> 1.1)
       regexp_parser (>= 2.0)
@@ -303,6 +307,7 @@ DEPENDENCIES
   rspec-daemon
   rubocop (~> 1.88)
   rubocop-rake
+  rubocop-rbs_inline
   rubocop-rspec
   steep
 

--- a/lib/rbs_discard/utils.rb
+++ b/lib/rbs_discard/utils.rb
@@ -4,7 +4,7 @@ require "rbs"
 
 module RbsDiscard
   module Utils
-    # @rbs klass_name: singleton(Object)
+    # @rbs klass: singleton(Object)
     def klass_to_names(klass) #: Array[RBS::TypeName]
       type_name = RBS::TypeName.parse("::#{klass.name}")
 

--- a/rbs_discard.gemspec
+++ b/rbs_discard.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A RBS files generator for discard gem"
   spec.homepage = "https://github.com/tk0miya/rbs_discard"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/sig/rbs_discard/utils.rbs
+++ b/sig/rbs_discard/utils.rbs
@@ -2,7 +2,7 @@
 
 module RbsDiscard
   module Utils
-    # @rbs klass_name: singleton(Object)
-    def klass_to_names: (untyped klass) -> Array[RBS::TypeName]
+    # @rbs klass: singleton(Object)
+    def klass_to_names: (singleton(Object) klass) -> Array[RBS::TypeName]
   end
 end


### PR DESCRIPTION
## Summary

This gem uses rbs-inline annotations in `lib` but did not lint them. Adds the `rubocop-rbs_inline` RuboCop plugin (and its cop configuration) to match the `init-ruby-project` skeleton.

`rubocop-rbs_inline` requires Ruby >= 3.3, so this also drops Ruby 3.2 support.

## Changes

- `Gemfile` / `Gemfile.lock`: add `rubocop-rbs_inline`
- `.rubocop.yml`: add `rubocop-rbs_inline` to `plugins` + `Style/RbsInline/*` settings
- `.github/workflows/main.yml`: drop Ruby 3.2 from the CI matrix
- `rbs_discard.gemspec`: bump `required_ruby_version` to `>= 3.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)