### PR TITLE
Introduce rubocop-numbered-params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 plugins:
+  - rubocop-numbered-params
   - rubocop-rake
   - rubocop-rbs_inline
   - rubocop-rspec

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem "rake", "~> 13.4"
 
 gem "rubocop", "~> 1.88"
+gem "rubocop-numbered-params"
 gem "rubocop-rake"
 gem "rubocop-rbs_inline"
 gem "rubocop-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,6 +244,9 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-numbered-params (1.0.0)
+      lint_roller (~> 1.0)
+      rubocop (>= 1.72.1)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
@@ -306,6 +309,7 @@ DEPENDENCIES
   rspec
   rspec-daemon
   rubocop (~> 1.88)
+  rubocop-numbered-params
   rubocop-rake
   rubocop-rbs_inline
   rubocop-rspec

--- a/rbs_discard.gemspec
+++ b/rbs_discard.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     end
   end
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.executables = spec.files.grep(%r{\Aexe/}) { File.basename(_1) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "discard"


### PR DESCRIPTION
Add the `rubocop-numbered-params` plugin to enforce a consistent style for numbered block parameters, matching the setup already used in other repositories.

- Add `rubocop-numbered-params` to the Gemfile and Gemfile.lock
- Register the plugin in `.rubocop.yml`
- Autocorrect existing offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)