### PR TITLE
Introduce rubocop-rspec-unused-let

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ plugins:
   - rubocop-rake
   - rubocop-rbs_inline
   - rubocop-rspec
+  - rubocop-rspec-unused-let
 
 # Layout
 Layout/LeadingCommentSpace:

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "rubocop-numbered-params"
 gem "rubocop-rake"
 gem "rubocop-rbs_inline"
 gem "rubocop-rspec"
+gem "rubocop-rspec-unused-let"
 
 group :development do
   gem "rbs-inline", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
+    ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     fileutils (1.8.0)
@@ -142,6 +143,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
@@ -258,6 +261,10 @@ GEM
       lint_roller (~> 1.1)
       regexp_parser (>= 2.0)
       rubocop (~> 1.86, >= 1.86.2)
+    rubocop-rspec-unused-let (1.2.0)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72)
+      rubocop-rspec (~> 3.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     steep (2.0.0)
@@ -297,6 +304,7 @@ GEM
     zeitwerk (2.7.5)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-darwin-23
   x86_64-darwin-24
@@ -313,6 +321,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rbs_inline
   rubocop-rspec
+  rubocop-rspec-unused-let
   steep
 
 BUNDLED WITH


### PR DESCRIPTION
Adds [rubocop-rspec-unused-let](https://github.com/tk0miya/rubocop-rspec-unused-let) and enables its `RSpec/UnusedLet` cop, which flags `let`/`subject` definitions and helper methods that are never referenced.

This repository's spec suite is already clean under the cop, so no code changes are needed — `bundle exec rubocop` reports no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)